### PR TITLE
test(coverage): added more tests covereage

### DIFF
--- a/.phpstan/resultCache.php
+++ b/.phpstan/resultCache.php
@@ -1934,6 +1934,73 @@ return [
       ),
     )),
   ),
+  'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php' => 
+  array (
+    0 => 
+    \PHPStan\Analyser\Error::__set_state(array(
+       'message' => 'Call to an undefined method Mockery\\ExpectationInterface|Mockery\\HigherOrderMessage::andReturn().',
+       'file' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'line' => 81,
+       'canBeIgnored' => true,
+       'filePath' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'traitFilePath' => NULL,
+       'tip' => NULL,
+       'nodeLine' => 81,
+       'nodeType' => 'PhpParser\\Node\\Expr\\MethodCall',
+       'identifier' => 'method.notFound',
+       'metadata' => 
+      array (
+      ),
+    )),
+    1 => 
+    \PHPStan\Analyser\Error::__set_state(array(
+       'message' => 'Call to an undefined method Mockery\\ExpectationInterface|Mockery\\HigherOrderMessage::andReturn().',
+       'file' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'line' => 102,
+       'canBeIgnored' => true,
+       'filePath' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'traitFilePath' => NULL,
+       'tip' => NULL,
+       'nodeLine' => 102,
+       'nodeType' => 'PhpParser\\Node\\Expr\\MethodCall',
+       'identifier' => 'method.notFound',
+       'metadata' => 
+      array (
+      ),
+    )),
+    2 => 
+    \PHPStan\Analyser\Error::__set_state(array(
+       'message' => 'Call to an undefined method ReflectionType::getName().',
+       'file' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'line' => 125,
+       'canBeIgnored' => true,
+       'filePath' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'traitFilePath' => NULL,
+       'tip' => NULL,
+       'nodeLine' => 125,
+       'nodeType' => 'PhpParser\\Node\\Expr\\MethodCall',
+       'identifier' => 'method.notFound',
+       'metadata' => 
+      array (
+      ),
+    )),
+    3 => 
+    \PHPStan\Analyser\Error::__set_state(array(
+       'message' => 'Call to an undefined method ReflectionType::getName().',
+       'file' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'line' => 186,
+       'canBeIgnored' => true,
+       'filePath' => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+       'traitFilePath' => NULL,
+       'tip' => NULL,
+       'nodeLine' => 186,
+       'nodeType' => 'PhpParser\\Node\\Expr\\MethodCall',
+       'identifier' => 'method.notFound',
+       'metadata' => 
+      array (
+      ),
+    )),
+  ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterTest.php' => 
   array (
     0 => 
@@ -2945,8 +3012,9 @@ return [
     array (
       0 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\src\\Console\\TestHuaweiObsCommand.php',
       1 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\src\\HuaweiObsServiceProvider.php',
-      2 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterHelperMethodsTest.php',
-      3 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterTest.php',
+      2 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php',
+      3 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterHelperMethodsTest.php',
+      4 => 'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterTest.php',
     ),
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\src\\HuaweiObsServiceProvider.php' => 
@@ -2960,35 +3028,35 @@ return [
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\Console\\TestHuaweiObsCommandTest.php' => 
   array (
-    'fileHash' => '6d1a64747ae6209e7ddacf951a941afd7a5212af',
+    'fileHash' => 'fab19856e6a68fdf8bb23eda84aae3b50870a057',
     'dependentFiles' => 
     array (
     ),
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\ExceptionsTest.php' => 
   array (
-    'fileHash' => '4953f05a7910f34fea0ddcd399d2fee04ff7bff1',
+    'fileHash' => '93923bdf5b93541bcb71e6fa30586a28ed605024',
     'dependentFiles' => 
     array (
     ),
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterHelperMethodsTest.php' => 
   array (
-    'fileHash' => '883acb98eec6dfc011474704d4dbf4c12297d629',
+    'fileHash' => 'f8319fd8a332895f1df5e1dfc404ee22e41181b7',
     'dependentFiles' => 
     array (
     ),
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsAdapterTest.php' => 
   array (
-    'fileHash' => 'ddc9f834836a38d4174e36bb43ec12057cfcd882',
+    'fileHash' => '916f78a4e509b5e4bf0dcd49f2b2a0a1c6c64852',
     'dependentFiles' => 
     array (
     ),
   ),
   'E:\\Freelancer\\laravel-flysystem-huawei-obs\\tests\\HuaweiObsServiceProviderTest.php' => 
   array (
-    'fileHash' => '689d3e888b2ded0cdb08c182e91cc79b8fcb1018',
+    'fileHash' => '160868e6cd779e41f7ebed5b2031683746672786',
     'dependentFiles' => 
     array (
     ),
@@ -5224,6 +5292,150 @@ return [
            'phpDoc' => NULL,
            'byRef' => false,
            'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        4 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_command_has_signature',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        5 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_get_adapter_with_valid_adapter',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        6 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_get_adapter_with_invalid_adapter',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        7 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_handle_method_exists',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        8 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_private_methods_exist',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        9 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_command_has_correct_properties',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        10 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'test_command_method_signatures',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => true,
+           'private' => false,
+           'abstract' => false,
+           'final' => false,
+           'static' => false,
+           'returnType' => 'void',
+           'parameters' => 
+          array (
+          ),
+           'attributes' => 
+          array (
+          ),
+        )),
+        11 => 
+        \PHPStan\Dependency\ExportedNode\ExportedMethodNode::__set_state(array(
+           'name' => 'tearDown',
+           'phpDoc' => NULL,
+           'byRef' => false,
+           'public' => false,
            'private' => false,
            'abstract' => false,
            'final' => false,

--- a/tests/Console/TestHuaweiObsCommandTest.php
+++ b/tests/Console/TestHuaweiObsCommandTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace LaravelFlysystemHuaweiObs\Tests\Console;
 
+use Illuminate\Contracts\Filesystem\Filesystem;
 use LaravelFlysystemHuaweiObs\Console\TestHuaweiObsCommand;
+use LaravelFlysystemHuaweiObs\HuaweiObsAdapter;
 use LaravelFlysystemHuaweiObs\HuaweiObsServiceProvider;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 
 class TestHuaweiObsCommandTest extends TestCase
@@ -47,5 +50,154 @@ class TestHuaweiObsCommandTest extends TestCase
             'Test Huawei OBS connectivity and basic operations',
             $command->getDescription()
         );
+    }
+
+    public function test_command_has_signature(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Use reflection to access the protected signature property
+        $reflection = new \ReflectionClass($command);
+        $signatureProperty = $reflection->getProperty('signature');
+        $signatureProperty->setAccessible(true);
+        $signature = $signatureProperty->getValue($command);
+
+        $this->assertStringContainsString('huawei-obs:test', $signature);
+        $this->assertStringContainsString('--disk=', $signature);
+        $this->assertStringContainsString('--write-test', $signature);
+        $this->assertStringContainsString('--read-test', $signature);
+        $this->assertStringContainsString('--delete-test', $signature);
+    }
+
+    public function test_get_adapter_with_valid_adapter(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Mock the HuaweiObsAdapter
+        $mockAdapter = Mockery::mock(HuaweiObsAdapter::class);
+
+        // Mock the Filesystem
+        $mockDisk = Mockery::mock(Filesystem::class);
+        $mockDisk->shouldReceive('getDriver->getAdapter')->andReturn($mockAdapter);
+
+        // Use reflection to access the private getAdapter method
+        $reflection = new \ReflectionClass($command);
+        $getAdapterMethod = $reflection->getMethod('getAdapter');
+        $getAdapterMethod->setAccessible(true);
+
+        $result = $getAdapterMethod->invoke($command, $mockDisk);
+
+        $this->assertSame($mockAdapter, $result);
+    }
+
+    public function test_get_adapter_with_invalid_adapter(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Mock a non-HuaweiObsAdapter
+        $mockAdapter = Mockery::mock('SomeOtherAdapter');
+
+        // Mock the Filesystem
+        $mockDisk = Mockery::mock(Filesystem::class);
+        $mockDisk->shouldReceive('getDriver->getAdapter')->andReturn($mockAdapter);
+
+        // Use reflection to access the private getAdapter method
+        $reflection = new \ReflectionClass($command);
+        $getAdapterMethod = $reflection->getMethod('getAdapter');
+        $getAdapterMethod->setAccessible(true);
+
+        $result = $getAdapterMethod->invoke($command, $mockDisk);
+
+        $this->assertNull($result);
+    }
+
+    public function test_handle_method_exists(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Use reflection to check that the handle method exists and is public
+        $reflection = new \ReflectionClass($command);
+        $handleMethod = $reflection->getMethod('handle');
+
+        $this->assertTrue($handleMethod->isPublic());
+        $returnType = $handleMethod->getReturnType();
+        $this->assertNotNull($returnType);
+        $this->assertEquals('int', $returnType->getName());
+    }
+
+    public function test_private_methods_exist(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Use reflection to check that all private methods exist
+        $reflection = new \ReflectionClass($command);
+
+        $expectedMethods = [
+            'getAdapter',
+            'testAuthentication',
+            'testWriteOperations',
+            'testReadOperations',
+            'testDeleteOperations',
+        ];
+
+        foreach ($expectedMethods as $methodName) {
+            $method = $reflection->getMethod($methodName);
+            $this->assertTrue($method->isPrivate(), "Method {$methodName} should be private");
+        }
+    }
+
+    public function test_command_has_correct_properties(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Use reflection to check the command properties
+        $reflection = new \ReflectionClass($command);
+
+        // Check signature property
+        $signatureProperty = $reflection->getProperty('signature');
+        $signatureProperty->setAccessible(true);
+        $signature = $signatureProperty->getValue($command);
+
+        $this->assertStringContainsString('huawei-obs:test', $signature);
+        $this->assertStringContainsString('{--disk=', $signature);
+        $this->assertStringContainsString('{--write-test', $signature);
+        $this->assertStringContainsString('{--read-test', $signature);
+        $this->assertStringContainsString('{--delete-test', $signature);
+
+        // Check description property
+        $descriptionProperty = $reflection->getProperty('description');
+        $descriptionProperty->setAccessible(true);
+        $description = $descriptionProperty->getValue($command);
+
+        $this->assertEquals('Test Huawei OBS connectivity and basic operations', $description);
+    }
+
+    public function test_command_method_signatures(): void
+    {
+        $command = new TestHuaweiObsCommand;
+
+        // Use reflection to check method signatures
+        $reflection = new \ReflectionClass($command);
+
+        // Check handle method signature
+        $handleMethod = $reflection->getMethod('handle');
+        $returnType = $handleMethod->getReturnType();
+        $this->assertNotNull($returnType);
+        $this->assertEquals('int', $returnType->getName());
+        $this->assertEquals(0, $handleMethod->getNumberOfParameters());
+
+        // Check private methods exist and are private
+        $privateMethods = ['getAdapter', 'testAuthentication', 'testWriteOperations', 'testReadOperations', 'testDeleteOperations'];
+
+        foreach ($privateMethods as $methodName) {
+            $method = $reflection->getMethod($methodName);
+            $this->assertTrue($method->isPrivate(), "Method {$methodName} should be private");
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the testing suite for the `TestHuaweiObsCommand` class, focusing on enhancing test coverage and addressing potential issues with method calls and file organization.

### Key Changes:

#### Test Enhancements:
1. **New Unit Tests for `TestHuaweiObsCommand`:**
   - Added tests to verify the command's signature, description, and method signatures.
   - Introduced tests for private methods like `getAdapter`, `testAuthentication`, `testWriteOperations`, `testReadOperations`, and `testDeleteOperations`.
   - Added `tearDown` to clean up Mockery instances after each test. (`tests/Console/TestHuaweiObsCommandTest.php`)

2. **Mocking and Reflection Usage:**
   - Utilized Mockery to mock dependencies (`HuaweiObsAdapter` and `Filesystem`) for testing.
   - Used PHP's Reflection API to access and validate private and protected properties and methods. (`tests/Console/TestHuaweiObsCommandTest.php`)

#### Codebase Maintenance:
3. **PHPStan Result Cache Updates:**
   - Updated `.phpstan/resultCache.php` to include new tests and reflect changes in file hashes for modified test files. [[1]](diffhunk://#diff-e2650df16f7515cbccac9e2e35fced9aa5f30cd19f550a0feb53c356332cf227L2948-R3017) [[2]](diffhunk://#diff-e2650df16f7515cbccac9e2e35fced9aa5f30cd19f550a0feb53c356332cf227L2963-R3059)

4. **Error Tracking:**
   - Added entries for new PHPStan errors related to undefined methods in `TestHuaweiObsCommandTest.php`. These errors are marked as ignorable.

5. **Exported Method Nodes:**
   - Updated exported nodes in `.phpstan/resultCache.php` to include new test methods.

These changes collectively improve the robustness of the testing framework and ensure better maintainability of the codebase.