### PR TITLE
fix: minimum laravel version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.2",
         "league/flysystem": "^3.0",
-        "laravel/framework": "^11.0",
+        "laravel/framework": ">=11.0",
         "obs/esdk-obs-php": "^3.0",
         "guzzlehttp/guzzle": "^7.0"
     },


### PR DESCRIPTION
This pull request makes a small adjustment to the `composer.json` file by modifying the version constraint for the `laravel/framework` dependency to allow for greater flexibility in version selection.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L25-R25): Changed the version constraint for `laravel/framework` from `^11.0` to `>=11.0` to allow for compatibility with future versions beyond the `11.x` series.