### PR TITLE
feat: minimum requirements update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,13 @@ jobs:
 
       - name: Install Laravel Testbench
         run: |
-          composer require "orchestra/testbench:^${{ matrix.laravel }}" --dev --no-interaction --no-update
+          if [ "${{ matrix.laravel }}" = "9.0" ]; then
+            composer require "orchestra/testbench:^7.0" --dev --no-interaction --no-update
+          elif [ "${{ matrix.laravel }}" = "10.0" ]; then
+            composer require "orchestra/testbench:^8.0" --dev --no-interaction --no-update
+          elif [ "${{ matrix.laravel }}" = "11.0" ]; then
+            composer require "orchestra/testbench:^9.0" --dev --no-interaction --no-update
+          fi
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.0, 10.0, 11.0]
+        laravel: [9.0, 10.0, 11.0, 12.0]
         exclude:
           - php: 8.3
             laravel: 9.0
@@ -40,6 +40,8 @@ jobs:
             composer require "orchestra/testbench:^8.0" --dev --no-interaction --no-update
           elif [ "${{ matrix.laravel }}" = "11.0" ]; then
             composer require "orchestra/testbench:^9.0" --dev --no-interaction --no-update
+          elif [ "${{ matrix.laravel }}" = "12.0" ]; then
+            composer require "orchestra/testbench:^10.0" --dev --no-interaction --no-update
           fi
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*, 11.*]
+        laravel: [9.0, 10.0, 11.0]
         exclude:
           - php: 8.3
-            laravel: 9.*
+            laravel: 9.0
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -29,7 +32,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mbstring, pdo_sqlite, intl
 
-      - name: Install Laravel Testbench version
+      - name: Install Laravel Testbench
         run: |
           composer require "orchestra/testbench:^${{ matrix.laravel }}" --dev --no-interaction --no-update
 
@@ -38,6 +41,7 @@ jobs:
 
       - name: Run PHPUnit Tests
         run: vendor/bin/phpunit
+
 
   phpstan:
     name: PHPStan Analysis
@@ -51,7 +55,10 @@ jobs:
           extensions: mbstring, intl, pdo_sqlite
 
       - run: composer install --prefer-dist --no-interaction
-      - run: composer phpstan
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse
+
 
   pint:
     name: Laravel Pint
@@ -65,4 +72,6 @@ jobs:
           extensions: mbstring
 
       - run: composer install --prefer-dist --no-interaction
-      - run: composer pint-test
+
+      - name: Run Laravel Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*, 11.*, 12.*]
+        php: [8.1, 8.2, 8.3]
+        laravel: [9.*, 10.*, 11.*]
         exclude:
-          - php: 8.0
-            laravel: 10.*
-          - php: 8.0
-            laravel: 11.*
-          - php: 8.0
-            laravel: 12.*
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
-            laravel: 12.*
           - php: 8.3
             laravel: 9.*
 
@@ -37,72 +27,42 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, pdo_sqlite
-          coverage: xdebug
+          extensions: mbstring, pdo_sqlite, intl
 
-      - name: Install correct Laravel/Testbench version
+      - name: Install Laravel Testbench version
         run: |
-          composer remove laravel/framework orchestra/testbench --dev --no-interaction || true
-          composer require "orchestra/testbench:^${{ matrix.laravel }}" --dev --no-interaction --update-with-dependencies
+          composer require "orchestra/testbench:^${{ matrix.laravel }}" --dev --no-interaction --no-update
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction
+        run: composer update --prefer-dist --no-interaction
 
-      - name: Run Tests with Coverage
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
-
-      - name: Verify coverage file exists
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "Error: coverage.xml file was not generated"
-            exit 1
-          fi
-          echo "Coverage file size: $(wc -c < coverage.xml) bytes"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: true
-          verbose: true
+      - name: Run PHPUnit Tests
+        run: vendor/bin/phpunit
 
   phpstan:
-    runs-on: ubuntu-latest
     name: PHPStan Analysis
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
           extensions: mbstring, intl, pdo_sqlite
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction
-
-      - name: Run PHPStan
-        run: composer phpstan
+      - run: composer install --prefer-dist --no-interaction
+      - run: composer phpstan
 
   pint:
-    runs-on: ubuntu-latest
     name: Laravel Pint
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          extensions: mbstring, intl, pdo_sqlite
+          extensions: mbstring
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction
-
-      - name: Run Laravel Pint
-        run: composer pint-test
+      - run: composer install --prefer-dist --no-interaction
+      - run: composer pint-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,100 +5,104 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
-  
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        php: [8.2, 8.3]
-        laravel: [11.*]
+        php: [8.0, 8.1, 8.2, 8.3]
+        laravel: [9.*, 10.*, 11.*, 12.*]
+        exclude:
+          - php: 8.0
+            laravel: 10.*
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.0
+            laravel: 12.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+          - php: 8.3
+            laravel: 9.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, iconv, json, mbstring, pdo, phar, reflection, session, simplexml, spl, standard, tokenizer, xml, xmlreader, xmlwriter, zip, zlib
-        coverage: xdebug
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, intl, pdo_sqlite
+          coverage: xdebug
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction
+      - name: Install correct Laravel/Testbench version
+        run: |
+          composer remove laravel/framework orchestra/testbench --dev --no-interaction || true
+          composer require "orchestra/testbench:^${{ matrix.laravel }}" --dev --no-interaction --update-with-dependencies
 
-    - name: Execute tests (via PHPUnit)
-      run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
 
-    - name: Verify coverage file exists
-      run: |
-        if [ ! -f coverage.xml ]; then
-          echo "Error: coverage.xml file was not generated"
-          exit 1
-        fi
-        echo "Coverage file size: $(wc -c < coverage.xml) bytes"
+      - name: Run Tests with Coverage
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
-        verbose: true
+      - name: Verify coverage file exists
+        run: |
+          if [ ! -f coverage.xml ]; then
+            echo "Error: coverage.xml file was not generated"
+            exit 1
+          fi
+          echo "Coverage file size: $(wc -c < coverage.xml) bytes"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true
 
   phpstan:
     runs-on: ubuntu-latest
     name: PHPStan Analysis
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 8.3
-        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, iconv, json, mbstring, pdo, phar, reflection, session, simplexml, spl, standard, tokenizer, xml, xmlreader, xmlwriter, zip, zlib
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: mbstring, intl, pdo_sqlite
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
 
-    - name: Run PHPStan
-      run: vendor/bin/phpstan analyse
+      - name: Run PHPStan
+        run: composer phpstan
 
   pint:
     runs-on: ubuntu-latest
     name: Laravel Pint
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: 8.3
-        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, iconv, json, mbstring, pdo, phar, reflection, session, simplexml, spl, standard, tokenizer, xml, xmlreader, xmlwriter, zip, zlib
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: mbstring, intl, pdo_sqlite
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-interaction
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
 
-    - name: Run Laravel Pint
-      run: vendor/bin/pint --test
-  commitlint-push:
-    runs-on: ubuntu-latest
-    name: Validate Commit Messages
-    if: github.event_name == 'push'
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Validate commit messages
-      uses: wagoid/commitlint-github-action@v5
-      with:
-        configFile: '@commitlint/config-conventional' 
+      - name: Run Laravel Pint
+        run: composer pint-test

--- a/.phpstan/resultCache.php
+++ b/.phpstan/resultCache.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
 return [
-	'lastFullAnalysisTime' => 1753990704,
+	'lastFullAnalysisTime' => 1754027396,
 	'meta' => array (
   'cacheVersion' => 'v12-linesToIgnore',
   'phpstanVersion' => '1.12.28',
@@ -17,7 +17,7 @@ return [
   ),
   'composerLocks' => 
   array (
-    'E:/Freelancer/laravel-flysystem-huawei-obs/composer.lock' => '3193a9c135c0bde07b1ac3e8c45464c5220b8b90',
+    'E:/Freelancer/laravel-flysystem-huawei-obs/composer.lock' => 'a310ad82682593970d0ae7b5d3c67f12d5f8f348',
   ),
   'composerInstalled' => 
   array (

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
   "require": {
     "php": "^8.1",
     "league/flysystem": "^3.0",
-    "laravel/framework": "^9.0|^10.0|^11.0",
+    "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
     "obs/esdk-obs-php": "^3.24.9",
     "guzzlehttp/guzzle": "^7.0|^8.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^7.0|^8.0|^9.0",
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
     "phpunit/phpunit": "^9.0|^10.0",
     "phpstan/phpstan": "^1.10",
     "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,75 @@
 {
-    "name": "mubbi/laravel-flysystem-huawei-obs",
-    "description": "Laravel Flysystem v3 adapter for Huawei Object Storage Service (OBS)",
-    "type": "library",
-    "version": "1.0.1",
-    "license": "MIT",
-    "keywords": [
-        "laravel",
-        "flysystem",
-        "huawei",
-        "obs",
-        "object-storage",
-        "filesystem"
-    ],
-    "authors": [
-        {
-            "name": "Mubbasher Ahmed",
-            "email": "hello@mubbi.me",
-            "homepage": "https://mubbi.me"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "league/flysystem": "^3.0",
-        "laravel/framework": ">=11.0",
-        "obs/esdk-obs-php": "^3.0",
-        "guzzlehttp/guzzle": "^7.0"
-    },
-    "require-dev": {
-        "orchestra/testbench": "^9.0",
-        "phpunit/phpunit": "^10.0",
-        "phpstan/phpstan": "^1.10",
-        "laravel/pint": "^1.13",
-        "mockery/mockery": "^1.6",
-        "fakerphp/faker": "^1.23"
-    },
-    "autoload": {
-        "psr-4": {
-            "LaravelFlysystemHuaweiObs\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "LaravelFlysystemHuaweiObs\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "LaravelFlysystemHuaweiObs\\HuaweiObsServiceProvider"
-            ]
-        }
-    },
-    "scripts": {
-        "test": "phpunit",
-        "test-coverage": "phpunit --coverage-html coverage",
-        "phpstan": "phpstan analyse",
-        "pint": "pint",
-        "pint-test": "pint --test",
-        "check": [
-            "@phpstan",
-            "@pint",
-            "@test"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "php-http/discovery": true
-        }
-    },
-    "minimum-stability": "stable",
-    "prefer-stable": true
+  "name": "mubbi/laravel-flysystem-huawei-obs",
+  "description": "Laravel Flysystem v3 adapter for Huawei Object Storage Service (OBS)",
+  "type": "library",
+  "version": "1.0.1",
+  "license": "MIT",
+  "keywords": [
+    "laravel",
+    "flysystem",
+    "huawei",
+    "obs",
+    "object-storage",
+    "filesystem"
+  ],
+  "authors": [
+    {
+      "name": "Mubbasher Ahmed",
+      "email": "hello@mubbi.me",
+      "homepage": "https://mubbi.me"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "league/flysystem": "^3.0",
+    "laravel/framework": "^9.0|^10.0|^11.0",
+    "obs/esdk-obs-php": "^3.24.9",
+    "guzzlehttp/guzzle": "^7.0|^8.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^7.0|^8.0|^9.0",
+    "phpunit/phpunit": "^9.0|^10.0",
+    "phpstan/phpstan": "^1.10",
+    "laravel/pint": "^1.0",
+    "mockery/mockery": "^1.6",
+    "fakerphp/faker": "^1.23"
+  },
+  "autoload": {
+    "psr-4": {
+      "LaravelFlysystemHuaweiObs\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "LaravelFlysystemHuaweiObs\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "LaravelFlysystemHuaweiObs\\HuaweiObsServiceProvider"
+      ]
+    }
+  },
+  "scripts": {
+    "test": "phpunit",
+    "test-coverage": "phpunit --coverage-html coverage",
+    "phpstan": "phpstan analyse",
+    "pint": "pint",
+    "pint-test": "pint --test",
+    "check": [
+      "@phpstan",
+      "@pint",
+      "@test"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "php-http/discovery": true
+    }
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
 } 


### PR DESCRIPTION
This pull request includes updates to dependency requirements and cache metadata. The most significant changes involve broadening PHP and package version compatibility, which enhances flexibility for different environments, and updating the PHPStan cache to reflect the latest analysis.

### Dependency Updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L23-R33): Adjusted PHP version requirement from `^8.2` to `^8.1` for broader compatibility. Updated package constraints for `laravel/framework`, `obs/esdk-obs-php`, `guzzlehttp/guzzle`, `orchestra/testbench`, and `phpunit/phpunit` to support multiple versions. Downgraded `laravel/pint` version requirement from `^1.13` to `^1.0`.

### Cache Metadata Updates:

* [`.phpstan/resultCache.php`](diffhunk://#diff-e2650df16f7515cbccac9e2e35fced9aa5f30cd19f550a0feb53c356332cf227L4-R4): Updated `lastFullAnalysisTime` and `composer.lock` hash to reflect the latest analysis and dependency state. [[1]](diffhunk://#diff-e2650df16f7515cbccac9e2e35fced9aa5f30cd19f550a0feb53c356332cf227L4-R4) [[2]](diffhunk://#diff-e2650df16f7515cbccac9e2e35fced9aa5f30cd19f550a0feb53c356332cf227L20-R20)