### PR TITLE
docs: guides update with correct versions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing to the Laravel Flysystem Huawei OBS 
 
 ### Prerequisites
 
-- PHP 8.2 or higher
+- PHP 8.1 or higher
 - Composer
 - Git
 - A Huawei Cloud OBS account (for testing)
@@ -96,7 +96,7 @@ composer pint
 - Follow [PSR-12](https://www.php-fig.org/psr/psr-12/) coding standards
 - Use strict typing (`declare(strict_types=1);`)
 - Use type hints for all parameters and return types
-- Use PHP 8.2+ features where appropriate
+- Use PHP 8.1+ features where appropriate
 
 ### Laravel Standards
 
@@ -323,7 +323,7 @@ for better clarity. Update your config/filesystems.php accordingly.
 ```
 docs: update installation guide with new requirements
 
-- Add PHP 8.2+ requirement
+- Add PHP 8.1+ requirement
 - Update Laravel version compatibility
 - Add troubleshooting section
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete documentation with usage examples
 
 ### Technical Features
-- Laravel 11+ compatibility
-- PHP 8.2+ requirement
+- Laravel 9.0+ compatibility (supports Laravel 9, 10, 11, and 12)
+- PHP 8.1+ requirement
 - Uses official `obs/esdk-obs-php` SDK
 - Proper exception handling with Flysystem exceptions
 - Type-safe implementation with strict typing

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ This package includes robust security features:
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11+
+- PHP 8.1+
+- Laravel 9.0+ (supports Laravel 9, 10, 11, and 12)
 - Huawei Cloud OBS account and credentials
 
 ## Installation


### PR DESCRIPTION
This pull request updates the minimum PHP and Laravel version requirements across the documentation to reflect broader compatibility. The key changes involve lowering the PHP requirement from 8.2 to 8.1 and expanding Laravel compatibility to include versions 9 through 12. These updates ensure the package is accessible to a wider range of users.

### Documentation Updates:

* [`.github/CONTRIBUTING.md`](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL21-R21): Updated the PHP requirement to 8.1+ in the prerequisites, coding standards, and installation guide sections. [[1]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL21-R21) [[2]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL99-R99) [[3]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL326-R326)
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL75-R76): Revised the compatibility details to specify support for Laravel 9.0+ (including versions 9, 10, 11, and 12) and updated the PHP requirement to 8.1+.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R49): Adjusted the requirements section to reflect PHP 8.1+ and Laravel 9.0+ compatibility.