### PR TITLE
fix: guzzle versions handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ This package includes robust security features:
 This package automatically detects and adapts to your installed versions of Guzzle:
 
 - **Guzzle v6**: Uses v6-specific client configurations
-- **Guzzle v7/v8**: Uses modern client configurations
+- **Guzzle v7**: Uses v7-specific client configurations
+- **Guzzle v8**: Uses v8-specific client configurations (with PSR-18 compliance)
 
 For Flysystem, the package uses v3 as the primary interface but maintains compatibility with v2 through dependency constraints. The package will automatically choose the correct HTTP client configuration based on your installed Guzzle version.
 

--- a/src/HttpClientFactory.php
+++ b/src/HttpClientFactory.php
@@ -127,24 +127,24 @@ class HttpClientFactory
         if ($reflection->hasMethod('getConfig')) {
             // Try to distinguish between v7 and v8 by checking for v8-specific features
             // Guzzle v8 has PSR-18 compliance and some additional methods
-            if (interface_exists('Psr\Http\Client\ClientInterface') && 
+            if (interface_exists('Psr\Http\Client\ClientInterface') &&
                 $reflection->implementsInterface('Psr\Http\Client\ClientInterface')) {
                 return 'v8';
             }
-            
+
             // Check for v8-specific methods or properties
-            if ($reflection->hasMethod('sendRequest') && 
+            if ($reflection->hasMethod('sendRequest') &&
                 method_exists(Client::class, 'sendRequest')) {
                 // Additional check for v8-specific behavior
                 $sendRequestMethod = $reflection->getMethod('sendRequest');
                 $parameters = $sendRequestMethod->getParameters();
-                if (count($parameters) === 1 && 
-                    $parameters[0]->getType() && 
+                if (count($parameters) === 1 &&
+                    $parameters[0]->getType() &&
                     $parameters[0]->getType()->getName() === 'Psr\Http\Message\RequestInterface') {
                     return 'v8';
                 }
             }
-            
+
             return 'v7';
         }
 

--- a/src/HttpClientFactory.php
+++ b/src/HttpClientFactory.php
@@ -61,8 +61,17 @@ class HttpClientFactory
             if (isset($config['allow_redirects'])) {
                 $clientConfig['allow_redirects'] = $config['allow_redirects'];
             }
+        } elseif ($guzzleVersion === 'v7') {
+            // Guzzle v7 specific configurations
+            if (isset($config['http_errors'])) {
+                $clientConfig['http_errors'] = $config['http_errors'];
+            }
+
+            if (isset($config['allow_redirects'])) {
+                $clientConfig['allow_redirects'] = $config['allow_redirects'];
+            }
         } else {
-            // Guzzle v7+ specific configurations
+            // Guzzle v8+ specific configurations
             if (isset($config['http_errors'])) {
                 $clientConfig['http_errors'] = $config['http_errors'];
             }
@@ -87,6 +96,25 @@ class HttpClientFactory
             return 'v7'; // Default fallback
         }
 
+        // Try to get version from Composer's installed packages
+        if (class_exists('Composer\InstalledVersions')) {
+            try {
+                $version = \Composer\InstalledVersions::getVersion('guzzlehttp/guzzle');
+                if ($version !== null) {
+                    $majorVersion = (int) explode('.', $version)[0];
+                    if ($majorVersion === 6) {
+                        return 'v6';
+                    } elseif ($majorVersion === 7) {
+                        return 'v7';
+                    } elseif ($majorVersion === 8) {
+                        return 'v8';
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Fallback to reflection-based detection
+            }
+        }
+
         // Fallback: check class methods to determine version
         $reflection = new \ReflectionClass(Client::class);
 
@@ -97,6 +125,26 @@ class HttpClientFactory
 
         // Check for v7+ specific methods
         if ($reflection->hasMethod('getConfig')) {
+            // Try to distinguish between v7 and v8 by checking for v8-specific features
+            // Guzzle v8 has PSR-18 compliance and some additional methods
+            if (interface_exists('Psr\Http\Client\ClientInterface') && 
+                $reflection->implementsInterface('Psr\Http\Client\ClientInterface')) {
+                return 'v8';
+            }
+            
+            // Check for v8-specific methods or properties
+            if ($reflection->hasMethod('sendRequest') && 
+                method_exists(Client::class, 'sendRequest')) {
+                // Additional check for v8-specific behavior
+                $sendRequestMethod = $reflection->getMethod('sendRequest');
+                $parameters = $sendRequestMethod->getParameters();
+                if (count($parameters) === 1 && 
+                    $parameters[0]->getType() && 
+                    $parameters[0]->getType()->getName() === 'Psr\Http\Message\RequestInterface') {
+                    return 'v8';
+                }
+            }
+            
             return 'v7';
         }
 

--- a/tests/CompatibilityTest.php
+++ b/tests/CompatibilityTest.php
@@ -14,7 +14,7 @@ class CompatibilityTest extends TestCase
         $version = HttpClientFactory::detectGuzzleVersion();
 
         $this->assertContains($version, ['v6', 'v7', 'v8']);
-        
+
         // Additional test to ensure the version is a valid string
         $this->assertIsString($version);
         $this->assertMatchesRegularExpression('/^v[678]$/', $version);

--- a/tests/CompatibilityTest.php
+++ b/tests/CompatibilityTest.php
@@ -14,6 +14,10 @@ class CompatibilityTest extends TestCase
         $version = HttpClientFactory::detectGuzzleVersion();
 
         $this->assertContains($version, ['v6', 'v7', 'v8']);
+        
+        // Additional test to ensure the version is a valid string
+        $this->assertIsString($version);
+        $this->assertMatchesRegularExpression('/^v[678]$/', $version);
     }
 
     public function test_http_client_factory_creates_client(): void


### PR DESCRIPTION
This pull request introduces enhancements to improve compatibility and version detection for Guzzle and updates related test cases. The most important changes include refining Guzzle version handling, enhancing the detection mechanism, and updating documentation to reflect these improvements.

### Guzzle Version Handling and Detection:

* [`src/HttpClientFactory.php`](diffhunk://#diff-3ec999ae69aeb041dfde9ff3981bee936b1a3f1a9ac79c27e35a5bdbeeb8e80bR61-R74): Updated the `create` method to include version-specific configurations for Guzzle v7 and v8, ensuring proper handling of `http_errors` and `allow_redirects` settings.  
* [`src/HttpClientFactory.php`](diffhunk://#diff-3ec999ae69aeb041dfde9ff3981bee936b1a3f1a9ac79c27e35a5bdbeeb8e80bR99-R117): Enhanced the `detectGuzzleVersion` method to use Composer's installed packages for version detection and added fallback mechanisms to distinguish between Guzzle v7 and v8 using PSR-18 compliance and v8-specific features. [[1]](diffhunk://#diff-3ec999ae69aeb041dfde9ff3981bee936b1a3f1a9ac79c27e35a5bdbeeb8e80bR99-R117) [[2]](diffhunk://#diff-3ec999ae69aeb041dfde9ff3981bee936b1a3f1a9ac79c27e35a5bdbeeb8e80bR128-R147)

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R77): Updated the Guzzle compatibility section to explicitly differentiate between v7 and v8 configurations, highlighting PSR-18 compliance for v8.

### Test Enhancements:

* [`tests/CompatibilityTest.php`](diffhunk://#diff-57e389fac501cf966793af3d35a499dae6319631583dd2d9e0b7c82025a1eb04R17-R20): Added assertions to validate that the detected Guzzle version is a valid string and matches the expected pattern (`v6`, `v7`, or `v8`).