### PR TITLE
fix(security): require Laravel 10.48.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ This package includes robust security features:
 ## Requirements
 
 - PHP 8.1+
-- Laravel 9.0+ (supports Laravel 9, 10, 11, and 12)
+- Laravel 9.0+ (supports Laravel 9, 10.48.29+, 11, and 12)
 - Flysystem v3.0+ (primary) with v2.0+ compatibility
 - Guzzle v6.3.0+, v7.0+, or v8.0+ (automatic detection)
 - Huawei Cloud OBS account and credentials
+
+> **⚠️ Security Notice:** Laravel 10.0.0 to 10.48.28 contains a file validation bypass vulnerability (CVE-2025-27515). This package requires Laravel 10.48.29+ to ensure security. Please upgrade your Laravel installation if you're using an affected version.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^8.1",
     "league/flysystem": "^2.0|^3.0",
-    "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+    "laravel/framework": "^9.0|^10.48.29|^11.0|^12.0",
     "obs/esdk-obs-php": "^3.24.9",
     "guzzlehttp/guzzle": "^6.3.0|^7.0|^8.0"
   },


### PR DESCRIPTION
This pull request updates the Laravel version requirements to address a security vulnerability and ensures compatibility with secure versions. The most important changes include updating the `composer.json` file and adding a security notice to the documentation.

### Security updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L25-R25): Updated the Laravel framework dependency to require version `10.48.29+` for Laravel 10, ensuring compatibility with the patched version that addresses CVE-2025-27515.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R70): Added a security notice about the file validation bypass vulnerability (CVE-2025-27515) in Laravel versions `10.0.0` to `10.48.28`, and emphasized the requirement to upgrade to `10.48.29+` for security.