### PR TITLE
fix: ci pipeline for minimum laravel v10.48.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.0, 10.0, 11.0, 12.0]
+        laravel: [9.0, 10.48.29, 11.0, 12.0]
         exclude:
           - php: 8.3
             laravel: 9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           if [ "${{ matrix.laravel }}" = "9.0" ]; then
             composer require "orchestra/testbench:^7.0" --dev --no-interaction --no-update
-          elif [ "${{ matrix.laravel }}" = "10.0" ]; then
+          elif [ "${{ matrix.laravel }}" = "10.48.29" ]; then
             composer require "orchestra/testbench:^8.0" --dev --no-interaction --no-update
           elif [ "${{ matrix.laravel }}" = "11.0" ]; then
             composer require "orchestra/testbench:^9.0" --dev --no-interaction --no-update


### PR DESCRIPTION
This pull request includes a small update to the CI workflow configuration. The change updates the Laravel version matrix to specify `10.48.29` instead of `10.0`. 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R19): Adjusted the Laravel version matrix under `jobs:` to use `10.48.29` instead of `10.0`.