### PR TITLE
fix: obs custom package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   ],
   "require": {
     "php": "^8.1",
-    "league/flysystem": "^2.0|^3.0",
+    "guzzlehttp/guzzle": "^6.3.0|^7.0|^8.0",
     "laravel/framework": "^9.0|^10.48.29|^11.0|^12.0",
-    "obs/esdk-obs-php": "^3.24.9",
-    "guzzlehttp/guzzle": "^6.3.0|^7.0|^8.0"
+    "league/flysystem": "^2.0|^3.0",
+    "mubbi/esdk-obs-php": "^3.24"
   },
   "require-dev": {
     "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
@@ -79,4 +79,4 @@
   },
   "minimum-stability": "stable",
   "prefer-stable": true
-} 
+}


### PR DESCRIPTION
This pull request updates the `composer.json` file to modify dependencies, primarily focusing on replacing and reordering packages for better compatibility and maintenance.

### Dependency updates:

* Replaced the `obs/esdk-obs-php` package with `mubbi/esdk-obs-php` and updated its version constraint to `^3.24`.
* Adjusted the order of dependencies, moving `league/flysystem` after `guzzlehttp/guzzle` for consistency.